### PR TITLE
[Fix]: Add language bundle var. Add warning suppression.

### DIFF
--- a/Sources/RswiftCore/CallInformation.swift
+++ b/Sources/RswiftCore/CallInformation.swift
@@ -32,6 +32,7 @@ public struct CallInformation {
   let sourceRootURL: URL
   let sdkRootURL: URL
   let platformURL: URL
+  let silenceLanguageWarnings: Bool
 
   public init(
     outputURL: URL,
@@ -54,7 +55,8 @@ public struct CallInformation {
     developerDirURL: URL,
     sourceRootURL: URL,
     sdkRootURL: URL,
-    platformURL: URL
+    platformURL: URL,
+    silenceLanguageWarnings: Bool
   ) {
     self.outputURL = outputURL
     self.uiTestOutputURL = uiTestOutputURL
@@ -77,6 +79,7 @@ public struct CallInformation {
     self.sourceRootURL = sourceRootURL
     self.sdkRootURL = sdkRootURL
     self.platformURL = platformURL
+    self.silenceLanguageWarnings = silenceLanguageWarnings
   }
 
 

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -12,10 +12,12 @@ import Foundation
 struct StringsStructGenerator: ExternalOnlyStructGenerator {
   private let localizableStrings: [LocalizableStrings]
   private let developmentLanguage: String
+  private let supressStringKeyWarnings: Bool
 
-  init(localizableStrings: [LocalizableStrings], developmentLanguage: String) {
+  init(localizableStrings: [LocalizableStrings], developmentLanguage: String, supressStringKeyWarnings: Bool) {
     self.localizableStrings = localizableStrings
     self.developmentLanguage = developmentLanguage
+    self.supressStringKeyWarnings = supressStringKeyWarnings
   }
 
   func generatedStruct(at externalAccessLevel: AccessLevel, prefix: SwiftIdentifier) -> Struct {
@@ -123,7 +125,9 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       let paddedKeys = missing.sorted().map { "'\($0)'" }
       let paddedKeysString = paddedKeys.joined(separator: ", ")
 
-      warn("Strings file \(filenameLocale) is missing translations for keys: \(paddedKeysString)")
+      if !supressStringKeyWarnings {
+          warn("Strings file \(filenameLocale) is missing translations for keys: \(paddedKeysString)")
+      }
     }
 
     // Warnings about extra translations
@@ -141,7 +145,9 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       let paddedKeys = extra.sorted().map { "'\($0)'" }
       let paddedKeysString = paddedKeys.joined(separator: ", ")
 
-      warn("Strings file \(filenameLocale) has extra translations (not in \(primaryLanguage)) for keys: \(paddedKeysString)")
+      if !supressStringKeyWarnings {
+          warn("Strings file \(filenameLocale) has extra translations (not in \(primaryLanguage)) for keys: \(paddedKeysString)")
+      }
     }
 
     // Only include translation if it exists in the primary language

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -247,7 +247,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
         Function.Parameter(
           name: "preferredLanguages",
           type: Type._Array.withGenericArgs([Type._String]).asOptional(),
-          defaultValue: "nil"
+          defaultValue: "[affirm_preferredLanguageIdentifier]"
         )
       ],
       doesThrow: false,
@@ -282,7 +282,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
     let prefereredLanguages = Function.Parameter(
       name: "preferredLanguages",
       type: Type._Array.withGenericArgs([Type._String]).asOptional(),
-      defaultValue: "nil"
+      defaultValue: "[affirm_preferredLanguageIdentifier]"
     )
     params.append(prefereredLanguages)
 

--- a/Sources/RswiftCore/RswiftCore.swift
+++ b/Sources/RswiftCore/RswiftCore.swift
@@ -76,7 +76,7 @@ public struct RswiftCore {
         structGenerators.append(ResourceFileStructGenerator(resourceFiles: resources.resourceFiles))
       }
       if callInformation.generators.contains(.string) {
-        structGenerators.append(StringsStructGenerator(localizableStrings: resources.localizableStrings, developmentLanguage: xcodeproj.developmentLanguage))
+          structGenerators.append(StringsStructGenerator(localizableStrings: resources.localizableStrings, developmentLanguage: xcodeproj.developmentLanguage, supressStringKeyWarnings: callInformation.silenceLanguageWarnings))
       }
       if callInformation.generators.contains(.id) {
         structGenerators.append(AccessibilityIdentifierStructGenerator(nibs: resources.nibs, storyboards: resources.storyboards))

--- a/Sources/RswiftCore/SwiftTypes/Let.swift
+++ b/Sources/RswiftCore/SwiftTypes/Let.swift
@@ -32,14 +32,16 @@ struct Let: UsedTypesProvider, SwiftCodeConverible {
   let name: SwiftIdentifier
   let typeDefinition: TypeDefinition
   let value: String
+  let mutable: Bool
 
-  init(comments: [String], accessModifier: AccessLevel, isStatic: Bool, name: SwiftIdentifier, typeDefinition: TypeDefinition, value: String) {
+  init(comments: [String], accessModifier: AccessLevel, isStatic: Bool, name: SwiftIdentifier, typeDefinition: TypeDefinition, mutable: Bool = false, value: String) {
     self.comments = comments
     self.accessModifier = accessModifier
     self.isStatic = isStatic
     self.name = name
     self.typeDefinition = typeDefinition
     self.value = value
+    self.mutable = mutable
   }
 
   var usedTypes: [UsedType] {
@@ -57,6 +59,6 @@ struct Let: UsedTypesProvider, SwiftCodeConverible {
     case .inferred: typeString = ""
     }
 
-    return "\(commentsString)\(accessModifierString)\(staticString)let \(name)\(typeString) = \(value)"
+    return "\(commentsString)\(accessModifierString)\(staticString)\(mutable ? "var" : "let") \(name)\(typeString) = \(value)"
   }
 }

--- a/Sources/RswiftCore/Util/Struct+InternalProperties.swift
+++ b/Sources/RswiftCore/Util/Struct+InternalProperties.swift
@@ -20,6 +20,14 @@ extension Struct {
     let internalProperties = [
       Let(
         comments: [],
+        accessModifier: .publicLevel,
+        isStatic: true,
+        name: "affirm_preferredLanguageIdentifier",
+        typeDefinition: .inferred(Type._String),
+        mutable: true,
+        value: "\"en\""), // Default to the english development language.
+      Let(
+        comments: [],
         accessModifier: .filePrivate,
         isStatic: true,
         name: "hostingBundle",


### PR DESCRIPTION
This does a couple things to unblock our downstream app:
- Changes struct generators to allow var and let options on variable creation.
- Adds language defaults to each generated string function.
- Adds new CLI flag to turn off missing string key warnings.