### PR TITLE
[IP-624] Don't Leak Sensitive Key Names

### DIFF
--- a/AffirmReadMe.md
+++ b/AffirmReadMe.md
@@ -18,7 +18,7 @@ Code generation extensions:
 
 * Added `AffirmLocalizedString` and `AffirmDisplayKey` to R.swift string generation to prevent
   leaking string key names if a language bundle is not found. This is only affects keys in
-  `Sensitive.strings` language tables.
+  `Confidential.strings` language tables.
 
 ## R.Swift Overview
 
@@ -32,7 +32,7 @@ R.swift this will no longer be needed as this will be included as part of the co
 
 ## Development Process
 
-1. Pull the repo from [https://github.com/Affirm/R.swift](https://github.com/Affirm/R.swift)
+1. Pull the repo from [https://github.com/Affirm/R.swift](https://github.com/Affirm/R.swift).
 
 2. Create your development branch off of `affirm-main` branch. The `affirm-main` is the branch
    with all the Affirm specific changes.
@@ -68,3 +68,4 @@ branch and rebase `affirm-main` onto it, preserving our changes when updating to
 1. Checkout `master`.
 2. Pull from their remote to refresh our master and push.
 3. Rebase `affirm-main` on top off the new master.
+4. Rebuild our tool.

--- a/AffirmReadMe.md
+++ b/AffirmReadMe.md
@@ -1,38 +1,38 @@
-# Updating R.swift
+# Affirm R.swift
 
 We use our own version of R.swift forked from [https://github.com/mac-cain13/R.swift](https://github.com/mac-cain13/R.swift).
 
-The Affirm repo is
+The Affirm repo is at [https://github.com/Affirm/R.swift](https://github.com/Affirm/R.swift).
 
-Our R.swift extensions:
+Extensions:
 
-* Adds new CLI flag to turn off missing string key warnings.
+* Adds a new CLI flag to turn off missing string warnings.
   - This is the `silenceLanguageWarnings` command flag.
 
 * Adds a default language to each generated string function.
   - Defaults to the current value of `R.affirm_preferredLanguageIdentifier`.
   - Changeable during runtime.
 
-* R.swift internal change that allows struct generators to create either var or let options on variables.
+* R.swift internal change that allows struct generators to create either var or let variables.
   - This was added to allow a `R.affirm_preferredLanguageIdentifier` to change during runtime.
 
 * Added `AffirmLocalizedString` and `AffirmDisplayKey` to R.swift string generation to prevent
-  leaking string key names if a language bundle is not found. This is only affects keys in the
-  `Sensitive.strings` language table.
+  leaking string key names if a language bundle is not found. This is only affects keys in
+  `Sensitive.strings` language tables.
 
 ## Development Process
 
 1. Pull the repo from [https://github.com/Affirm/R.swift](https://github.com/Affirm/R.swift)
 
-2. Create your development branch off of `affirm-main` branch. The `affirm-main` is our main branch
+2. Create your development branch off of `affirm-main` branch. The `affirm-main` is the branch
    with all the Affirm specific changes.
 
-3. When opening a PR, use `affirm-main` as the base branch and land your changes there. You'll need
-   a PR review to land to `affirm-main`.
+3. When opening a PR, use `Affirm` / `affirm-main` as the base branch and land your changes there.
+   You'll need a PR review to land to `affirm-main`.
 
 4. You can open the R.swift `Package.swift` in Xcode like a project file and code using the IDE.
 
-The R.swift coding philosophy is helpful in understanding why their design choices:
+The R.swift coding philosophy is helpful in understanding their design choices:
 [R.swift development philosophy](https://github.com/mac-cain13/R.swift/issues/177)
 
 We don't strictly follow this but it's nice to know.
@@ -49,11 +49,11 @@ swift build -c release --arch arm64 --arch x86_64 # Make a fat binary.
 The build products are in the `./.build` folder which is helpfully a hidden dot directory. Open it
 with `open ./build` and it'll open in a Finder window.
 
-## Updating R.Swift to the latest version.
+## Updating Affirm R.Swift to the latest origin version
 
-All the Affirm changes are on `affirm-main` so we can pull the fork origin `master` branch and rebase
+All the Affirm changes are on `affirm-main` so we can pull the fork-origin `master` branch and rebase
 `affirm-main` onto it, preserving our changes when updating to the latest R.swift.
 
 1. Checkout `master`.
-2. Pull from their remote to refresh our master.
+2. Pull from their remote to refresh our master and push.
 3. Rebase `affirm-main` on top off the new master.

--- a/AffirmReadMe.md
+++ b/AffirmReadMe.md
@@ -4,7 +4,7 @@ We use our own version of R.swift forked from [https://github.com/mac-cain13/R.s
 
 The Affirm repo is at [https://github.com/Affirm/R.swift](https://github.com/Affirm/R.swift).
 
-Extensions:
+Code generation extensions:
 
 * Adds a new CLI flag to turn off missing string warnings.
   - This is the `silenceLanguageWarnings` command flag.
@@ -13,12 +13,22 @@ Extensions:
   - Defaults to the current value of `R.affirm_preferredLanguageIdentifier`.
   - Changeable during runtime.
 
-* R.swift internal change that allows struct generators to create either var or let variables.
-  - This was added to allow a `R.affirm_preferredLanguageIdentifier` to change during runtime.
+* An R.swift internal change that allows struct generators to create either `var` or `let` variables.
+  - This was added to allow changes to `R.affirm_preferredLanguageIdentifier` during runtime.
 
 * Added `AffirmLocalizedString` and `AffirmDisplayKey` to R.swift string generation to prevent
   leaking string key names if a language bundle is not found. This is only affects keys in
   `Sensitive.strings` language tables.
+
+## R.Swift Overview
+
+R.swift scans the resources of an Xcode project and generates type safe and name safe Swift code
+that loads the resources. The `rswift` command line tool generates the files at build time.
+
+R.swift also has a support library called `R.swift.Library` located at
+[mac-cain13/R.swift.Library](https://github.com/mac-cain13/R.swift.Library). The library contains
+class extensions and helper code to make R.swift easier to use. After we upgrade to version 7 of
+R.swift this will no longer be needed as this will be included as part of the code generation.
 
 ## Development Process
 
@@ -30,29 +40,30 @@ Extensions:
 3. When opening a PR, use `Affirm` / `affirm-main` as the base branch and land your changes there.
    You'll need a PR review to land to `affirm-main`.
 
-4. You can open the R.swift `Package.swift` in Xcode like a project file and code using the IDE.
+4. You can open the R.swift `Package.swift` like an Xcode project file and code using the IDE while
+   updating the code.
 
 The R.swift coding philosophy is helpful in understanding their design choices:
 [R.swift development philosophy](https://github.com/mac-cain13/R.swift/issues/177)
 
-We don't strictly follow this but it's nice to know.
+The Affirm extensions don't strictly follow the philosophy but it's nice to know.
 
 ### Command Line Builds
 
 ```bash
 cd ./R.swift
-swift build # Build for debug.
+swift build # Build for debugging.
 swift test  # Run tests
-swift build -c release --arch arm64 --arch x86_64 # Make a fat binary.
+swift build -c release --arch arm64 --arch x86_64 # Make a release fat binary.
 ```
 
-The build products are in the `./.build` folder which is helpfully a hidden dot directory. Open it
-with `open ./build` and it'll open in a Finder window.
+The build products are in the `.build` folder which is a hidden dot directory (so helpful). Open
+it from the command line with `open .build` and it'll open in a Finder window.
 
 ## Updating Affirm R.Swift to the latest origin version
 
-All the Affirm changes are on `affirm-main` so we can pull the fork-origin `master` branch and rebase
-`affirm-main` onto it, preserving our changes when updating to the latest R.swift.
+All the Affirm changes are on the `affirm-main` branch so we can pull the fork-origin `master`
+branch and rebase `affirm-main` onto it, preserving our changes when updating to the latest R.swift.
 
 1. Checkout `master`.
 2. Pull from their remote to refresh our master and push.

--- a/AffirmReadMe.md
+++ b/AffirmReadMe.md
@@ -1,0 +1,69 @@
+# Updating R.swift
+
+We use our own version of R.swift forked from https://github.com/mac-cain13/R.swift.
+
+## Development Process
+
+Pull the repo.
+
+Develop off of `affirm-main`.
+This is the branch with all the Affirm specific stuff so we can pull the `master` branch and rebase
+`affirm-main` onto it, preserving our changes when updating to the latest R.swift.
+
+To make changes, pull affirm-main and create your development branch from it.
+When opening a PR, use `affirm-main` as the base branch. You'll need to
+
+## Command Line Build
+
+cd ./R.swift
+swift build # Build for debug.
+swift test  # Run tests
+swift build -c release # Build a release version.
+
+swift build -c release --arch arm64 --arch x86_64 # Fat binary.
+
+Coding philosophy:
+https://github.com/mac-cain13/R.swift/issues/177
+
+```
+      static func AffirmLocalizedString(_ key: String, tableName: String, bundle: Bundle, comment: String) -> String {
+        let result = NSLocalizedString(key, tableName: tableName, bundle: bundle, comment: comment)
+        return (tableName.lowercased() == "sensitive" && result == key) ? "" : result
+      }
+
+      static func AffirmDisplayKey(_ key: String, tableName: String) -> String {
+        return (tableName.lowercased() == "sensitive") ? "" : key
+      }
+
+      static func AffirmLocalizedString(_ stringResource: Rswift.StringResource, preferredLanguages: [String]?) -> String {
+        guard let preferredLanguages = preferredLanguages else {
+          return AffirmLocalizedString(stringResource.key, tableName: stringResource.tableName, bundle: hostingBundle, comment: "")
+        }
+
+        guard let (_, bundle) = localeBundle(tableName: stringResource.tableName, preferredLanguages: preferredLanguages) else {
+          return AffirmDisplayKey(stringResource.key, tableName: stringResource.tableName)
+        }
+        return AffirmLocalizedString(stringResource.key, tableName: stringResource.tableName, bundle: bundle, comment: "")
+      }
+
+      #if false
+      /// en translation: Example string
+      ///
+      /// Locales: en, en-CA, fr-CA
+      static func exampleString(preferredLanguages: [String]? = [affirm_preferredLanguageIdentifier]) -> String {
+        guard let preferredLanguages = preferredLanguages else {
+          return NSLocalizedString("example.string", tableName: "Sensitive", bundle: hostingBundle, comment: "")
+        }
+
+        guard let (_, bundle) = localeBundle(tableName: "Sensitive", preferredLanguages: preferredLanguages) else {
+          return "example.string"
+        }
+
+        return NSLocalizedString("example.string", tableName: "Sensitive", bundle: bundle, comment: "")
+      }
+      #else
+      static func exampleString(preferredLanguages: [String]? = [affirm_preferredLanguageIdentifier]) -> String {
+        return AffirmLocalizedString(exampleString, preferredLanguages: preferredLanguages)
+      }
+      #endif
+```

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -35,7 +35,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
 
     let AffirmLocalizedString = Function(
       availables: [],
-      comments: ["Returns an NSLocalizedString with the key hidden for sensitive strings."],
+      comments: ["Returns an NSLocalizedString with the key hidden for confidential strings."],
       accessModifier: externalAccessLevel,
       isStatic: true,
       name: "AffirmLocalizedString",
@@ -67,13 +67,13 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       returnType: Type._String,
       body: """
         let result = NSLocalizedString(key, tableName: tableName, bundle: bundle, comment: comment)
-        return (tableName.lowercased() == "sensitive" && result == key) ? "" : result
+        return (tableName.lowercased() == "confidential" && result == key) ? "" : result
         """,
       os: []
     )
     let AffirmDisplayKey = Function(
       availables: [],
-      comments: ["Returns a sanitized key if tableName is 'sensitive'."],
+      comments: ["Returns a sanitized key if tableName is 'confidential'."],
       accessModifier: externalAccessLevel,
       isStatic: true,
       name: "AffirmDisplayKey",
@@ -94,7 +94,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       doesThrow: false,
       returnType: Type._String,
       body: """
-        return (tableName.lowercased() == "sensitive") ? "" : key
+        return (tableName.lowercased() == "confidential") ? "" : key
         """,
       os: []
     )

--- a/Sources/RswiftCore/Generators/StringsStructGenerator.swift
+++ b/Sources/RswiftCore/Generators/StringsStructGenerator.swift
@@ -33,6 +33,73 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       return stringStructFromLocalizableStrings(filename: key, strings: value, at: externalAccessLevel, prefix: qualifiedName)
     }
 
+    let AffirmLocalizedString = Function(
+      availables: [],
+      comments: ["Returns an NSLocalizedString with the key hidden for sensitive strings."],
+      accessModifier: externalAccessLevel,
+      isStatic: true,
+      name: "AffirmLocalizedString",
+      generics: nil,
+      parameters: [
+        Function.Parameter(
+          name: "_",
+          localName: "key",
+          type: Type._String,
+          defaultValue: nil
+        ),
+        Function.Parameter(
+          name: "tableName",
+          type: Type._String,
+          defaultValue: nil
+        ),
+        Function.Parameter(
+          name: "bundle",
+          type: Type._Bundle,
+          defaultValue: nil
+        ),
+        Function.Parameter(
+          name: "comment",
+          type: Type._String,
+          defaultValue: nil
+        ),
+      ],
+      doesThrow: false,
+      returnType: Type._String,
+      body: """
+        let result = NSLocalizedString(key, tableName: tableName, bundle: bundle, comment: comment)
+        return (tableName.lowercased() == "sensitive" && result == key) ? "" : result
+        """,
+      os: []
+    )
+    let AffirmDisplayKey = Function(
+      availables: [],
+      comments: ["Returns a sanitized key if tableName is 'sensitive'."],
+      accessModifier: externalAccessLevel,
+      isStatic: true,
+      name: "AffirmDisplayKey",
+      generics: nil,
+      parameters: [
+        Function.Parameter(
+          name: "_",
+          localName: "key",
+          type: Type._String,
+          defaultValue: nil
+        ),
+        Function.Parameter(
+          name: "tableName",
+          type: Type._String,
+          defaultValue: nil
+        ),
+      ],
+      doesThrow: false,
+      returnType: Type._String,
+      body: """
+        return (tableName.lowercased() == "sensitive") ? "" : key
+        """,
+      os: []
+    )
+
+
     return Struct(
       availables: [],
       comments: ["This `\(qualifiedName)` struct is generated, and contains static references to \(groupedLocalized.uniques.count) localization tables."],
@@ -41,7 +108,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
       implements: [],
       typealiasses: [],
       properties: [],
-      functions: [],
+      functions: [AffirmLocalizedString, AffirmDisplayKey],
       structs: structs,
       classes: [],
       os: []
@@ -264,7 +331,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
         }
 
         guard let (_, bundle) = localeBundle(tableName: "\(values.tableName)", preferredLanguages: preferredLanguages) else {
-          return "\(values.key.escapedStringLiteral)"
+          return AffirmDisplayKey("\(values.key.escapedStringLiteral)", tableName: "\(values.tableName)")
         }
 
         return \(values.swiftCode(bundle: "bundle"))
@@ -309,7 +376,7 @@ struct StringsStructGenerator: ExternalOnlyStructGenerator {
         }
 
         guard let (locale, bundle) = localeBundle(tableName: "\(values.tableName)", preferredLanguages: preferredLanguages) else {
-          return "\(values.key.escapedStringLiteral)"
+          return AffirmDisplayKey("\(values.key.escapedStringLiteral)", tableName: "\(values.tableName)")
         }
 
         let format = \(values.swiftCode(bundle: "bundle"))
@@ -349,12 +416,7 @@ private struct StringValues {
       valueArgument = ", value: \"\(value.escapedStringLiteral)\""
     }
 
-    if tableName == "Localizable" {
-      return "NSLocalizedString(\"\(escapedKey)\", bundle: \(bundle)\(valueArgument), comment: \"\")"
-    }
-    else {
-      return "NSLocalizedString(\"\(escapedKey)\", tableName: \"\(tableName)\", bundle: \(bundle)\(valueArgument), comment: \"\")"
-    }
+    return "AffirmLocalizedString(\"\(escapedKey)\", tableName: \"\(tableName)\", bundle: \(bundle)\(valueArgument), comment: \"\")"
   }
 
   var baseLanguageValue: String? {


### PR DESCRIPTION
## Summary

* Don't leak sensitive key names if the localized key / string is in the `Sensitive` bundle.
* Created and updated our documentation in `AffirmReadMe.md`.

## Reviewers

@clementyau 
@Affirm/ios-platform 

## Test Plan

Unit tests pass.
Tested with main app.